### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/paulokenji17-lab/juice-shop-ada/security/code-scanning/54](https://github.com/paulokenji17-lab/juice-shop-ada/security/code-scanning/54)

To fix this vulnerability, we must avoid passing user-controlled data into the `$where` operator in MongoDB queries, as this operator interprets its string as JavaScript and is never safe with dynamic input. Instead, we should use a direct query filter: `{ orderId: id }`, which safely matches the orderId field for equality, with no code execution risk. This change maintains all existing logic and output. The fix only needs to be applied on line 18 in `routes/trackOrder.ts` by replacing the use of `$where` with a standard property filter. No additional library is needed; just update the query logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
